### PR TITLE
Delete .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-config.js


### PR DESCRIPTION
After discussing with the TA, since we're hosting our project on Git Pages, there is no way to hide the API keys and have the project actually work. Therefore .gitignore needs to go away so config.js will be pushed to the repository. 